### PR TITLE
Rollback grasping version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "PyTorchGrasping"]
 	path = PyTorchGrasping
 	url = git@github.com:xc-jp/PyTorchGrasping.git
-	branch = kowa/v1.2.1
+	branch = kowa/v1.2.0


### PR DESCRIPTION
We are using a model trained with grasping version kowa/v1.2.0. Therefore the grasping version used for inference must be the same.
This PR changes the Grasping submodule to be kowa/v1.2.0